### PR TITLE
Using the right case for the Arduino.h file

### DIFF
--- a/a21/ec11.hpp
+++ b/a21/ec11.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <arduino.h>
+#include <Arduino.h>
 
 namespace a21 {
 

--- a/a21/pins.hpp
+++ b/a21/pins.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <arduino.h>
+#include <Arduino.h>
 
 namespace a21 {
 


### PR DESCRIPTION
I use a case-sensitive filesystem and this was breaking compilation.